### PR TITLE
db: add teams table and seed data

### DIFF
--- a/scripts/sql/001_create_teams.sql
+++ b/scripts/sql/001_create_teams.sql
@@ -1,0 +1,16 @@
+USE foosball;
+
+CREATE TABLE IF NOT EXISTS teams (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  rating INT NOT NULL DEFAULT 1500,
+  wins INT NOT NULL DEFAULT 0,
+  games_played INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+INSERT INTO teams (name, rating, wins, games_played) VALUES
+('Alex', 1500, 0, 0),
+('Ben', 1500, 0, 0),
+('Chris', 1500, 0, 0),
+('Dana', 1500, 0, 0);


### PR DESCRIPTION
Creates the `teams` table (`id, name, rating, wins, games_played, created_at`) in the `foosball` schema
and seeds four initial rows (Alex, Ben, Chris, Dana — rating 1500, wins 0, games 0).

SQL file: `scripts/sql/001_create_teams.sql`

**Test**
- Run the script (DBeaver Alt+X or MySQL CLI).
- `SELECT COUNT(*) FROM teams;` → expected: `4`.
