### PR TITLE
feat: /match/new — match entry form (no save yet)

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,9 +1,29 @@
 body { font-family: system-ui, Arial, sans-serif; margin: 24px; background: #0b0f14; color: #e6f0ff; }
+
 .container { max-width: 960px; margin: 0 auto; }
+
 .muted { color: #9db2d1; }
+
 .card { background: rgba(255,255,255,0.06); border-radius: 12px; padding: 16px; box-shadow: 0 8px 24px rgba(0,0,0,0.25); }
+
 .table { width: 100%; border-collapse: collapse; }
+
 .table th, .table td { padding: 10px 8px; border-bottom: 1px solid rgba(255,255,255,0.10); text-align: left; }
+
 .table th { color: #9db2d1; font-weight: 600; }
+
 a { color: #33e1ed; text-decoration: none; }
+
 a:hover { text-decoration: underline; }
+
+.row { display:flex; gap:12px; align-items:center; margin:10px 0; }
+
+.row label { width:120px; color:#9db2d1; }
+
+.row select, .row input { flex:1; padding:8px 10px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:#0f141b; color:#e6f0ff; }
+
+.actions { display:flex; gap:12px; margin-top:12px; }
+
+.btn { display:inline-block; padding:8px 12px; border-radius:10px; background:rgba(255,255,255,0.06); color:#e6f0ff; text-decoration:none; border:1px solid rgba(255,255,255,0.12); }
+
+.btn.primary { background:#1b2a38; border-color:#2a3b4e; }

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,24 +9,33 @@ function route(string $method, string $path): string {
         return (string)ob_get_clean();
     }
 
-if ($method === 'GET' && $path === '/leaderboard') {
-    $title = 'Leaderboard';
+    if ($method === 'GET' && $path === '/leaderboard') {
+        $title = 'Leaderboard';
 
-    $pdo = db();
-    $stmt = $pdo->query("
-        SELECT id, name, rating, wins, games_played
-        FROM teams
-        ORDER BY rating DESC, wins DESC, games_played DESC
-        LIMIT 50
-    ");
-    $teams = $stmt->fetchAll();
+        $pdo = db();
+        $stmt = $pdo->query("
+            SELECT id, name, rating, wins, games_played
+            FROM teams
+            ORDER BY rating DESC, wins DESC, games_played DESC
+            LIMIT 50
+        ");
+        $teams = $stmt->fetchAll();
 
-    ob_start();
-    include __DIR__ . '/../views/leaderboard.php';
-    return (string)ob_get_clean();
-}
+        ob_start();
+        include __DIR__ . '/../views/leaderboard.php';
+        return (string)ob_get_clean();
+    }
 
+    if ($method === 'GET' && $path === '/match/new') {
+        $title = 'New Match';
 
+        $pdo = db();
+        $teams = $pdo->query("SELECT id, name FROM teams ORDER BY name ASC")->fetchAll();
+
+        ob_start();
+        include __DIR__ . '/../views/match_new.php';
+        return (string)ob_get_clean();
+    }
 
     http_response_code(404);
     return 'Not found';

--- a/views/home.php
+++ b/views/home.php
@@ -2,4 +2,5 @@
 <h1>Foosball Scoreboard</h1>
 <p>Router & Views funktionieren !!</p>
 <p><a href="/leaderboard"> Zum Leaderboard</a></p>
+<p><a href="/match/new">➕ New Match</a></p>
 <?php $content = ob_get_clean(); include __DIR__ . '/layout.php'; ?>

--- a/views/match_new.php
+++ b/views/match_new.php
@@ -1,0 +1,70 @@
+<?php ob_start(); ?>
+<h1>New Match</h1>
+<p class="muted">Nur Formular – Speichern kommt im nächsten Schritt.</p>
+
+<form action="/match" method="post" class="card" onsubmit="return false;">
+    <div class="row">
+        <label for="mode">Mode</label>
+        <select id="mode" name="mode" required>
+            <option value="1v1">1v1</option>
+            <option value="2v2">2v2</option>
+        </select>
+    </div>
+
+    <div class="row">
+        <label for="team_a">Team A</label>
+        <select id="team_a" name="team_a_id" required>
+            <option value="" disabled selected>Choose team…</option>
+            <?php foreach ($teams as $t): ?>
+            <option value="<?= (int)$t['id'] ?>"><?= htmlspecialchars($t['name']) ?></option>
+            <?php endforeach; ?>
+        </select>
+    </div>
+
+    <div class="row">
+        <label for="team_b">Team B</label>
+        <select id="team_b" name="team_b_id" required>
+            <option value="" disabled selected>Choose team…</option>
+            <?php foreach ($teams as $t): ?>
+            <option value="<?= (int)$t['id'] ?>"><?= htmlspecialchars($t['name']) ?></option>
+            <?php endforeach; ?>
+        </select>
+    </div>
+
+    <div class="row">
+        <label for="score_a">Score A</label>
+        <input id="score_a" name="score_a" type="number" min="0" step="1" value="0" required>
+    </div>
+
+    <div class="row">
+        <label for="score_b">Score B</label>
+        <input id="score_b" name="score_b" type="number" min="0" step="1" value="0" required>
+    </div>
+
+    <div class="row">
+        <label for="notes">Notes (optional)</label>
+        <input id="notes" name="notes" type="text" placeholder="e.g. friendly match">
+    </div>
+
+    <div class="actions">
+        <a class="btn" href="/leaderboard">← Back</a>
+        <!-- submit ist noch disabled, da POST im nächsten Step kommt -->
+        <button class="btn primary" type="button" disabled title="Save follows in next step">Save (next step)</button>
+    </div>
+</form>
+
+<script>
+// einfache Client-Validierung: gleiche Teams verhindern
+const a = document.getElementById('team_a');
+const b = document.getElementById('team_b');
+
+function preventSame() {
+    if (a.value && b.value && a.value === b.value) {
+        alert('Team A und Team B dürfen nicht gleich sein.');
+        b.value = '';
+    }
+}
+a.addEventListener('change', preventSame);
+b.addEventListener('change', preventSame);
+</script>
+<?php $content = ob_get_clean(); include __DIR__ . '/layout.php'; ?>


### PR DESCRIPTION
Adds the `/match/new` page:

- GET route in `routes/web.php` (loads teams from `teams` for both selects)
- View `views/match_new.php` with fields: mode, team A/B, scores, notes
- Basic client-side check: Team A ≠ Team B
- Minimal styles in `public/css/style.css`

**How to test**
1) Run `php -S localhost:8000 -t public`
2) Open `http://localhost:8000/match/new`
3) Teams from DB appear in both dropdowns; form renders without errors