### PR TITLE
ui: add Bootstrap via CDN and base dark layout

### DIFF
--- a/views/layout.php
+++ b/views/layout.php
@@ -4,15 +4,23 @@
 
 <head>
     <meta charset="utf-8">
-    <title><?= htmlspecialchars($title ?? 'App') ?></title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?= htmlspecialchars($title ?? 'Foosball Scoreboard') ?></title>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
     <link href="/css/style.css" rel="stylesheet">
 </head>
 
-<body>
-    <main class="container">
+<body class="bg-dark text-light">
+    <main class="container py-4">
         <?= $content ?? '' ?>
     </main>
+
+    <!-- Bootstrap Bundle (JS + Popper) -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Adds Bootstrap 5 via CDN and wires a base dark layout (`views/layout.php`) with container and bundle script.
No view changes yet; pages render as before using Bootstrap base.