### PR TITLE
feat(ui): modern navbar + redesigned home (hero, stats, recent matches)

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -140,3 +140,62 @@ a:hover{ color:#7feaf2; text-decoration: underline; }
 }
 
 #btnMute { min-width: 2.2rem; text-align: center; }
+
+ /* Glassy Navbar */
+    .glass-nav {
+      background: rgba(255,255,255,0.06);
+      border-bottom: 1px solid rgba(255,255,255,0.12);
+      backdrop-filter: blur(10px);
+    }
+    .navbar-brand {
+      font-weight: 700;
+      letter-spacing: .3px;
+      display: flex; align-items: center; gap:.5rem;
+    }
+    .brand-badge {
+      padding:.15rem .45rem; border-radius:.5rem;
+      background: rgba(255,255,255,.08);
+      border:1px solid rgba(255,255,255,.15);
+      font-size:.75rem;
+    }
+    .navbar-nav .nav-link {
+      position: relative;
+    }
+    .navbar-nav .nav-link.active,
+    .navbar-nav .nav-link:hover {
+      color: var(--acc1, #33e1ed);
+    }
+    .navbar-nav .nav-link::after {
+      content:''; position:absolute; left:.5rem; right:.5rem; bottom:.35rem;
+      height:2px; background: currentColor; opacity:0; transform: scaleX(0);
+      transition: transform .18s ease, opacity .18s ease;
+    }
+    .navbar-nav .nav-link:hover::after,
+    .navbar-nav .nav-link.active::after {
+      opacity:.9; transform: scaleX(1);
+    }
+    .sticky-top { top:0; }
+    .fx-bg { z-index: 0; } /* hinter Navbar */
+    nav.navbar { z-index: 10; }
+    main.container { position: relative; z-index: 1; }
+
+    /* Stat cards */
+.card-stat {
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 14px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.25);
+}
+
+/* Hover cards */
+.hover-card {
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.10);
+  transition: transform .16s ease, box-shadow .16s ease, border-color .16s ease;
+  border-radius: 14px;
+}
+.hover-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(255,255,255,0.18);
+  box-shadow: 0 14px 38px rgba(0,0,0,0.35);
+}

--- a/public/index.php
+++ b/public/index.php
@@ -1,13 +1,20 @@
 <?php
 declare(strict_types=1);
 
-require __DIR__ . '/../src/db.php';
 require __DIR__ . '/../src/security.php';
 csrf_start();
+require __DIR__ . '/../src/db.php';
 require __DIR__ . '/../routes/web.php';
 
 
-$path   = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?: '/';
+$reqPath   = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/';
+$scriptDir = rtrim(dirname($_SERVER['SCRIPT_NAME'] ?? ''), '/\\');
+if ($scriptDir !== '' && $scriptDir !== '/') {
+    if (strpos($reqPath, $scriptDir) === 0) {
+        $reqPath = substr($reqPath, strlen($scriptDir)) ?: '/';
+    }
+}
+$path   = $reqPath;
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 
 echo route($method, $path);

--- a/routes/web.php
+++ b/routes/web.php
@@ -63,12 +63,32 @@ function finish_match(PDO $pdo, int $matchId): array {
    =========================== */
 function route(string $method, string $path): string {
 
-    /* ---- HTML: Home ---- */
-    if ($method === 'GET' && $path === '/') {
-        $title = 'Foosball Scoreboard';
-        ob_start(); include __DIR__ . '/../views/home.php';
-        return (string)ob_get_clean();
-    }
+   // Home
+if ($method === 'GET' && $path === '/') {
+    $title = 'Foosball Scoreboard';
+    $pdo = db();
+    // kleine Stats + 5 letzte Matches
+    $stats = [
+        'teams'    => (int)$pdo->query("SELECT COUNT(*) FROM teams")->fetchColumn(),
+        'matches'  => (int)$pdo->query("SELECT COUNT(*) FROM matches")->fetchColumn(),
+        'finished' => (int)$pdo->query("SELECT COUNT(*) FROM matches WHERE status='finished'")->fetchColumn(),
+    ];
+    $recent = $pdo->query("
+        SELECT m.id, m.played_at, m.status, m.score_a, m.score_b,
+               a.name AS team_a, b.name AS team_b
+        FROM matches m
+        JOIN teams a ON a.id = m.team_a_id
+        JOIN teams b ON b.id = m.team_b_id
+        ORDER BY m.id DESC
+        LIMIT 5
+    ")->fetchAll();
+
+    ob_start(); 
+    include __DIR__ . '/../views/home.php';
+    include __DIR__ . '/../views/teams_index.php';
+    return (string)ob_get_clean();
+}
+
 
     /* ---- HTML: Leaderboard ---- */
     if ($method === 'GET' && $path === '/leaderboard') {
@@ -432,6 +452,22 @@ function route(string $method, string $path): string {
         ob_start(); include __DIR__ . '/../views/matches_index.php';
         return (string)ob_get_clean();
     }
+
+// --- Teams (read-only list) ---
+if ($method === 'GET' && $path === '/teams') {
+    $title = 'Teams';
+    $pdo = db();
+    $teams = $pdo->query("
+        SELECT id, name, rating, wins, games_played, created_at
+        FROM teams
+        ORDER BY name ASC
+    ")->fetchAll();
+
+    ob_start();
+    include __DIR__ . '/../views/teams_index.php';
+    return (string)ob_get_clean();
+}
+
 
     /* ---- Fallback ---- */
     http_response_code(404);

--- a/views/home.php
+++ b/views/home.php
@@ -1,6 +1,105 @@
 <?php ob_start(); ?>
-<h1>Foosball Scoreboard</h1>
-<p>Router & Views funktionieren !!</p>
-<p><a href="/leaderboard"> Zum Leaderboard</a></p>
-<p><a href="/match/new">➕ New Match</a></p>
+<section class="py-4">
+    <div class="text-center mb-4">
+        <h1 class="display-5 fw-bold" style="letter-spacing:.5px;">
+            <span
+                style="background:linear-gradient(90deg, var(--acc1,#33e1ed), var(--acc2,#ff5da2)); -webkit-background-clip:text; background-clip:text; color:transparent;">
+                Foosball Scoreboard
+            </span>
+        </h1>
+        <p class="lead muted mb-3">Track matches, live scores, and rankings — fast and beautiful.</p>
+        <div class="d-flex justify-content-center gap-2 flex-wrap">
+            <a class="btn btn-primary btn-lg" href="/match/new">Start a Match</a>
+            <a class="btn btn-outline-info btn-lg" href="/leaderboard">View Leaderboard</a>
+        </div>
+    </div>
+
+    <?php if (!empty($stats) && is_array($stats)): ?>
+    <div class="row g-3 mb-4">
+        <div class="col-md-4">
+            <div class="card card-stat text-center">
+                <div class="card-body">
+                    <div class="h2 mb-1"><?= (int)($stats['teams'] ?? 0) ?></div>
+                    <div class="muted">Teams</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card card-stat text-center">
+                <div class="card-body">
+                    <div class="h2 mb-1"><?= (int)($stats['matches'] ?? 0) ?></div>
+                    <div class="muted">Matches</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card card-stat text-center">
+                <div class="card-body">
+                    <div class="h2 mb-1"><?= (int)($stats['finished'] ?? 0) ?></div>
+                    <div class="muted">Finished</div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <?php endif; ?>
+
+    <div class="row g-3">
+        <div class="col-md-6">
+            <a href="/matches" class="text-decoration-none">
+                <div class="card h-100 hover-card">
+                    <div class="card-body">
+                        <h3 class="h5 mb-2">Match History</h3>
+                        <p class="muted mb-0">Browse, filter by team or date, and paginate recent matches.</p>
+                    </div>
+                </div>
+            </a>
+        </div>
+        <div class="col-md-6">
+            <a href="/teams" class="text-decoration-none">
+                <div class="card h-100 hover-card">
+                    <div class="card-body">
+                        <h3 class="h5 mb-2">Teams</h3>
+                        <p class="muted mb-0">See all registered teams with ratings and records.</p>
+                    </div>
+                </div>
+            </a>
+        </div>
+    </div>
+
+    <?php if (!empty($recent) && is_array($recent)): ?>
+    <div class="card bg-transparent border-0 shadow-soft mt-4">
+        <div class="card-body p-0">
+            <div class="p-2 muted small">Recent matches</div>
+            <table class="table table-hover mb-0">
+                <thead>
+                    <tr>
+                        <th style="width:80px;">ID</th>
+                        <th style="width:160px;">Date</th>
+                        <th>Teams</th>
+                        <th style="width:120px;">Score</th>
+                        <th style="width:120px;">Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($recent as $m): ?>
+                    <tr>
+                        <td><a href="/match/<?= (int)$m['id'] ?>">#<?= (int)$m['id'] ?></a></td>
+                        <td><?= htmlspecialchars(date('Y-m-d H:i', strtotime($m['played_at'] ?? 'now'))) ?></td>
+                        <td><?= htmlspecialchars($m['team_a']) ?> vs <?= htmlspecialchars($m['team_b']) ?></td>
+                        <td><?= (int)$m['score_a'] ?> : <?= (int)$m['score_b'] ?></td>
+                        <td>
+                            <?php if (($m['status'] ?? 'in_progress') === 'finished'): ?>
+                            <span class="badge bg-success">finished</span>
+                            <?php else: ?>
+                            <span class="badge bg-secondary">in&nbsp;progress</span>
+                            <?php endif; ?>
+                        </td>
+                    </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <?php endif; ?>
+</section>
 <?php $content = ob_get_clean(); include __DIR__ . '/layout.php'; ?>

--- a/views/layout.php
+++ b/views/layout.php
@@ -1,35 +1,80 @@
-<?php /** @var string $title */ ?>
+<?php
+declare(strict_types=1);
+/** @var string|null $title */
+/** @var string|null $content */
+$pageTitle = isset($title) && $title !== '' ? $title . ' · Foosball' : 'Foosball Scoreboard';
+$cur = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/';
+$active = function(string $p) use ($cur): string {
+  if ($p === '/') return $cur === '/' ? 'active' : '';
+  return (strpos($cur, $p) === 0) ? 'active' : '';
+};
+?>
 <!doctype html>
-<html lang="de">
+<html lang="en">
 
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title><?= htmlspecialchars($title ?? 'Foosball Scoreboard') ?></title>
-
-    <!-- Calendar picker -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/themes/dark.css">
-    <script defer src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
-
+    <meta name="color-scheme" content="dark light">
     <?php if (function_exists('csrf_token')): ?>
     <meta name="csrf-token" content="<?= htmlspecialchars(csrf_token(), ENT_QUOTES) ?>">
     <?php endif; ?>
 
+    <title><?= htmlspecialchars($pageTitle) ?></title>
 
-
+    <!-- Bootstrap -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/style.css" rel="stylesheet">
+    <!-- Flatpickr (nur für /matches Filter) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/themes/dark.css">
+    <!-- Theme -->
+    <link rel="stylesheet" href="/css/style.css">
+
 </head>
 
-<body class="bg-dark text-light">
-    <!-- Animated background layers -->
-    <div class="fx-bg"></div>
+<body>
+    <!-- animierter Hintergrund -->
+    <div class="fx-bg" aria-hidden="true"></div>
 
-    <main class="container py-4 position-relative">
+    <!-- Navbar -->
+    <nav class="navbar navbar-expand-md glass-nav sticky-top">
+        <div class="container">
+            <a class="navbar-brand" href="/">
+                <!-- kleines Icon -->
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="M7 4h10l1 4-6 3-6-3 1-4zm-2 16h14v-2l-5-3-2 1-2-1-5 3v2z" />
+                </svg>
+                Foosball <span class="brand-badge">Scoreboard</span>
+            </a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav"
+                aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon" style="filter: invert(1);"></span>
+            </button>
+
+            <div class="collapse navbar-collapse" id="mainNav">
+                <ul class="navbar-nav me-auto mb-2 mb-md-0">
+                    <li class="nav-item"><a class="nav-link <?= $active('/leaderboard') ?>"
+                            href="/leaderboard">Leaderboard</a></li>
+                    <li class="nav-item"><a class="nav-link <?= $active('/matches') ?>" href="/matches">History</a></li>
+                    <li class="nav-item"><a class="nav-link <?= $active('/teams') ?>" href="/teams">Teams</a></li>
+                </ul>
+                <div class="d-flex">
+                    <a class="btn btn-primary" href="/match/new">+ New Match</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Inhalt -->
+    <main class="container my-3">
         <?= $content ?? '' ?>
     </main>
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <footer class="container my-4">
+        <p class="muted small mb-0">Foosball Scoreboard • <?= date('Y') ?></p>
+    </footer>
+
+    <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 </body>
 
 </html>

--- a/views/leaderboard.php
+++ b/views/leaderboard.php
@@ -1,8 +1,4 @@
 <?php ob_start(); ?>
-<div class="d-flex align-items-center justify-content-between mb-3">
-    <h1 class="h3 mb-0">Leaderboard</h1>
-    <a class="btn btn-outline-info btn-sm" href="/">Home</a>
-</div>
 
 <?php if (empty($teams)): ?>
 <div class="alert alert-warning">No teams yet.</div>

--- a/views/match_new.php
+++ b/views/match_new.php
@@ -1,11 +1,4 @@
 <?php ob_start(); ?>
-<div class="d-flex align-items-center justify-content-between mb-3">
-    <h1 class="h3 mb-0">New Match</h1>
-    <div class="d-flex gap-2">
-        <a class="btn btn-outline-info btn-sm" href="/leaderboard">Leaderboard</a>
-        <a class="btn btn-outline-secondary btn-sm" href="/matches">History</a>
-    </div>
-</div>
 
 <?php if (!empty($errors)): ?>
 <div class="alert alert-danger">

--- a/views/match_show.php
+++ b/views/match_show.php
@@ -1,12 +1,4 @@
 <?php ob_start(); ?>
-<div class="d-flex align-items-center justify-content-between mb-3">
-    <h1 class="h3 mb-0">Match #<?= (int)$match['id'] ?></h1>
-    <div class="d-flex gap-2">
-        <a class="btn btn-outline-info btn-sm" href="/leaderboard">Leaderboard</a>
-        <a class="btn btn-outline-secondary btn-sm" href="/matches">History</a>
-        <a class="btn btn-primary btn-sm" href="/match/new">+ New Match</a>
-    </div>
-</div>
 
 <?php if (!empty($created)): ?>
 <div class="alert alert-success py-2">Match created — adjust scores on this TV view.</div>
@@ -328,7 +320,8 @@ window.addEventListener('keydown', async (e) => {
             btnFinish?.click();
         }
     } catch (_) {
-        /* Fehler werden bereits angezeigt */ }
+        /* Fehler werden bereits angezeigt */
+    }
 });
 </script>
 <?php $content = ob_get_clean(); include __DIR__ . '/layout.php'; ?>

--- a/views/matches_index.php
+++ b/views/matches_index.php
@@ -1,11 +1,4 @@
 <?php ob_start(); ?>
-<div class="d-flex align-items-center justify-content-between mb-3">
-    <h1 class="h3 mb-0">Matches</h1>
-    <div class="d-flex gap-2">
-        <a class="btn btn-outline-info btn-sm" href="/leaderboard">Leaderboard</a>
-        <a class="btn btn-primary btn-sm" href="/match/new">+ New Match</a>
-    </div>
-</div>
 
 <!-- Filter -->
 <form class="card bg-transparent border-0 shadow-sm mb-3" method="get" action="/matches">

--- a/views/teams_index.php
+++ b/views/teams_index.php
@@ -1,0 +1,39 @@
+<?php ob_start(); ?>
+<div class="d-flex align-items-center justify-content-between mb-3">
+
+    <h1 class="h3 mb-0">Teams</h1>
+
+
+    <div class="card bg-transparent border-0 shadow-sm">
+        <div class="card-body p-0">
+            <?php if (empty($teams)): ?>
+            <div class="p-4 muted">No teams yet.</div>
+            <?php else: ?>
+            <table class="table table-hover mb-0">
+                <thead>
+                    <tr>
+                        <th style="width:80px;">ID</th>
+                        <th>Name</th>
+                        <th style="width:120px;">Rating</th>
+                        <th style="width:120px;">Wins</th>
+                        <th style="width:140px;">Games</th>
+                        <th style="width:180px;">Created</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($teams as $t): ?>
+                    <tr>
+                        <td>#<?= (int)$t['id'] ?></td>
+                        <td><?= htmlspecialchars($t['name']) ?></td>
+                        <td><?= (int)$t['rating'] ?></td>
+                        <td><?= (int)$t['wins'] ?></td>
+                        <td><?= (int)$t['games_played'] ?></td>
+                        <td><?= htmlspecialchars(date('Y-m-d H:i', strtotime($t['created_at'] ?? 'now'))) ?></td>
+                    </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+            <?php endif; ?>
+        </div>
+    </div>
+    <?php $content = ob_get_clean(); include __DIR__ . '/layout.php'; ?>


### PR DESCRIPTION
feat(ui): modern navbar + redesigned home (hero, stats, recent matches)

- Replace per-view header buttons with a global glassy, sticky navbar
- Redesign / (home): hero section, quick stats, quick links
- Show 5 recent matches on home
- Add small CSS for stat/hover cards
- Update home route to provide stats & recent
- Keep dark/neon theme and CSRF meta; no DB changes
